### PR TITLE
PHARMA-001: Define first pilot GxP boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,5 @@ CI runs the same command for pull requests and pushes to `main`.
 
 - `.gitignore` keeps local/generated artifacts out of source control without hiding documentation, validation templates, fixtures, or GitHub workflow files.
 - `.github/workflows/ci.yml` runs the baseline verification command.
+- The [first pilot intended use and GxP boundary](docs/intended-use.md) document defines the supported scaffolding and out-of-scope regulated operations.
 - `docs/validation-templates/` is reserved for future validation-ready templates and examples.

--- a/docs/intended-use.md
+++ b/docs/intended-use.md
@@ -1,0 +1,41 @@
+# First Pilot Intended Use and GxP Boundary
+
+## Intended Use
+
+The first Ensen-flow-pharma pilot provides validation-ready scaffolding for future Pharma/GxP workflow packages used with Ensen Flow. It may define draft package structure, documentation patterns, evidence placeholders, and validation-template examples that help a team plan a later regulated workflow implementation.
+
+The pilot is an authoring and planning aid. It is not a production quality system, live operational integration, or regulated decision engine.
+
+## Supported Pilot Scaffolding
+
+- Repo-local intended-use, boundary, and validation-readiness documentation.
+- Draft template locations for future validation assets.
+- Explicit terminology for expected human control points.
+- Examples that can be reviewed, revised, and approved by qualified humans before any regulated use.
+
+## GxP Boundary
+
+The pilot boundary is validation-ready scaffolding only. It does not claim that any workflow, template, package, or connected system is validated or acceptable for regulated execution.
+
+Later issues must preserve these control points:
+
+- Read-only inputs: pilot materials may describe or consume copied examples, exported samples, or documented source assumptions, but must not write back to source systems.
+- Draft-only outputs: generated or assembled materials are drafts until reviewed and approved through a separate qualified process.
+- Human approval: a qualified human must approve any regulated use, release decision, disposition decision, or quality action outside this pilot repository.
+
+## Explicit Exclusions
+
+The first pilot does not provide:
+
+- Batch release.
+- Final product disposition.
+- Automated quality decisions.
+- Live ERPNext operation.
+- ERPNext connector behavior or write-back behavior.
+- Electronic signature implementation.
+- Compliance guarantees for Part 11, Annex 11, GxP validation, or similar regulatory obligations.
+- Runtime workflow execution for regulated operations.
+
+## Implementation Guardrail
+
+Future work may add mappings, validation package templates, or review scaffolds only if they keep the same boundary: read-only inputs, draft-only outputs, and required human approval before regulated use. Missing provenance, unclear scope, unauthenticated identity, placeholder credentials, or unapproved boundary signals must block regulated use rather than being treated as sufficient context.

--- a/scripts/verify-pre-pr.mjs
+++ b/scripts/verify-pre-pr.mjs
@@ -6,6 +6,7 @@ const requiredFiles = [
   ".gitignore",
   ".github/workflows/ci.yml",
   "README.md",
+  "docs/intended-use.md",
   "docs/validation-templates/README.md",
   "package.json",
   "scripts/verify-pre-pr.mjs"
@@ -59,7 +60,7 @@ for (const sourcePath of [
   }
 }
 
-for (const path of ["README.md", "docs/validation-templates/README.md"]) {
+for (const path of ["README.md", "docs/intended-use.md", "docs/validation-templates/README.md"]) {
   if (!(await fileExists(path))) {
     continue;
   }
@@ -68,6 +69,32 @@ for (const path of ["README.md", "docs/validation-templates/README.md"]) {
   for (const pattern of forbiddenClaims) {
     if (pattern.test(contents)) {
       failures.push(`Forbidden compliance guarantee language found in ${path}: ${pattern}`);
+    }
+  }
+}
+
+if (await fileExists("README.md")) {
+  const readme = readFileSync("README.md", "utf8");
+  if (!/\[[^\]]*intended use[^\]]*\]\(docs\/intended-use\.md\)/i.test(readme)) {
+    failures.push("README.md must link to docs/intended-use.md with intended-use navigation text.");
+  }
+}
+
+if (await fileExists("docs/intended-use.md")) {
+  const intendedUse = readFileSync("docs/intended-use.md", "utf8").toLowerCase();
+  for (const phrase of [
+    "read-only inputs",
+    "draft-only outputs",
+    "human approval",
+    "batch release",
+    "final product disposition",
+    "automated quality decisions",
+    "live erpnext operation",
+    "electronic signature implementation",
+    "compliance guarantees"
+  ]) {
+    if (!intendedUse.includes(phrase)) {
+      failures.push(`docs/intended-use.md must name the boundary phrase: ${phrase}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add the first pilot intended-use and GxP boundary document
- link the new boundary document from README navigation
- tighten pre-PR verification so the boundary doc, README navigation, control-point phrases, and forbidden guarantee language are checked

## Verification
- npm run verify:pre-pr

Refs #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation

* Introduced comprehensive intended-use documentation defining the pilot's scope, supported scaffolding capabilities and documentation patterns, GxP regulatory boundaries and compliance limitations, mandatory human approval control points, and explicit operational exclusions.
* Updated README with reference to the intended-use documentation to clarify supported capabilities and regulatory boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->