### PR TITLE
PHARMA-010: Add ERPNext object mapping draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,4 +19,5 @@ CI runs the same command for pull requests and pushes to `main`.
 - `.gitignore` keeps local/generated artifacts out of source control without hiding documentation, validation templates, fixtures, or GitHub workflow files.
 - `.github/workflows/ci.yml` runs the baseline verification command.
 - The [first pilot intended use and GxP boundary](docs/intended-use.md) document defines the supported scaffolding and out-of-scope regulated operations.
+- The [ERPNext object mapping draft](docs/erpnext-object-mapping.md) identifies candidate source objects, Ensen-flow-pharma concepts, data classification notes, future usage, and evidence/audit implications.
 - `docs/validation-templates/` is reserved for future validation-ready templates and examples.

--- a/docs/erpnext-object-mapping.md
+++ b/docs/erpnext-object-mapping.md
@@ -1,0 +1,38 @@
+# ERPNext Object Mapping Draft
+
+## Status and Boundary
+
+This document is a first-pass ERPNext object mapping draft for future Pharma/GxP workflow scaffolding. Every field, workflow, object relationship, and usage note remains draft until validated against a real owner-controlled ERPNext environment in a later phase.
+
+The mapping is documentation only. It does not add a live ERPNext connector, API call, credential path, write-back behavior, regulated workflow operation, electronic signature behavior, batch release, final product disposition, automated quality decision, or compliance guarantee.
+
+## Intended Mapping Use
+
+The future usage for this draft is read-only planning of workflow package structure, evidence placeholders, validation-template coverage, and human review checkpoints. Any future implementation must keep read-only inputs, draft-only outputs, and qualified human approval outside this repository before regulated use.
+
+Data classification values are planning labels for repository documentation. They are not a substitute for a validated data inventory, owner-approved classification, or system-specific risk assessment.
+
+## Object Mapping
+
+| ERPNext source object | Ensen-flow-pharma concept | Data classification | Future usage | Evidence and audit implications |
+| --- | --- | --- | --- | --- |
+| `Item` | Material or product master reference | Potential GxP master data; may include product, material, and quality-relevant attributes | Draft package scoping, material identity references, and human review prompts | Preserve source object name, owner-controlled identifier, draft snapshot timestamp, and reviewer note fields. Do not infer release or disposition status from the record alone. |
+| `Batch` | Batch or lot context | Potential GxP operational data; may be regulated depending on local process ownership | Draft batch-context placeholder for validation examples and evidence grouping | Capture copied batch identifier, source environment label, and provenance note. Missing provenance must block regulated use. |
+| `Batch Manufacturing Record` | Manufacturing execution evidence anchor | Potential high-impact GxP execution record | Future read-only evidence index for human review of manufacturing steps | Track document identifier, revision or status visible in the owner system, extraction method, and review status. Do not treat the draft mapping as execution control. |
+| `Quality Inspection` | Quality result evidence | Potential GxP quality data | Draft evidence checklist for inspection result availability and human assessment | Preserve source inspection identifier, linked item or batch if explicitly present, result status as copied context, and reviewer disposition notes. No automated quality decisions. |
+| `Material Request` | Supply or movement intent | Business operational data with possible GxP relevance when tied to controlled materials | Draft dependency context for workflow package examples | Record source identifier and explicit linkage to material or batch only when present in the owner-controlled source. Do not infer GxP impact from naming alone. |
+| `Purchase Receipt` | Supplier receipt evidence | Potential GxP receipt or chain-of-custody evidence | Draft incoming-material evidence reference | Capture supplier, receipt identifier, date, and linked material context as copied fields. Human review must decide fitness for regulated evidence use. |
+| `Stock Entry` | Inventory movement evidence | Potential GxP operational data | Draft material movement context for traceability examples | Preserve movement identifier, movement type, linked item or batch, and copied timestamp. No write-back, inventory adjustment, or status mutation. |
+| `Work Order` | Planned production activity | Potential GxP process planning data | Draft workflow package context for planned or historical production steps | Capture work order identifier, linked item, status as copied context, and owner-system provenance. Do not use this draft to start, complete, or approve work. |
+| `Job Card` | Operation-level execution detail | Potential GxP execution data | Draft operation evidence anchor for human review checklists | Preserve operation identifier, linked work order when explicit, and copied completion context. Electronic signature and operator identity controls are out of scope. |
+| `BOM` | Recipe or bill-of-materials reference | Potential GxP master data | Draft package dependency reference for material and process structure | Capture BOM identifier, version if available, and linked item context. Treat all recipe use as draft until validated by the process owner. |
+| `Serial No` | Unit-level traceability context | Potential GxP traceability data | Draft traceability example when unit-level identity is relevant | Record source serial identifier and explicit batch or item linkage only when present. Do not broaden traceability by path shape or naming convention. |
+| `Supplier` | Supplier identity reference | Supplier master data; may support GxP supplier qualification context | Draft evidence context for incoming-material examples | Capture supplier identifier and copied status or qualification context only as source-system evidence. This mapping does not approve suppliers. |
+
+## Future Validation Notes
+
+- A later owner-controlled environment review must confirm exact ERPNext object names, enabled modules, custom fields, permissions, and lifecycle states before any implementation relies on this draft.
+- Future connector work must fail closed when source identity, provenance, tenant or environment binding, object linkage, or authorization context is missing or malformed.
+- Future evidence exports must identify copied records, source timestamps, and review status without claiming that draft records are approved regulated evidence.
+- Future audit behavior must distinguish source-system audit trails from Ensen-flow-pharma draft review notes. This repository does not create a regulated audit trail.
+- Any electronic signature, approval workflow, live ERPNext connector, write-back path, or regulated workflow operation must be designed and validated outside this Phase 1 mapping draft.

--- a/scripts/verify-pre-pr.mjs
+++ b/scripts/verify-pre-pr.mjs
@@ -6,6 +6,7 @@ const requiredFiles = [
   ".gitignore",
   ".github/workflows/ci.yml",
   "README.md",
+  "docs/erpnext-object-mapping.md",
   "docs/intended-use.md",
   "docs/validation-templates/README.md",
   "package.json",
@@ -60,7 +61,7 @@ for (const sourcePath of [
   }
 }
 
-for (const path of ["README.md", "docs/intended-use.md", "docs/validation-templates/README.md"]) {
+for (const path of ["README.md", "docs/erpnext-object-mapping.md", "docs/intended-use.md", "docs/validation-templates/README.md"]) {
   if (!(await fileExists(path))) {
     continue;
   }
@@ -77,6 +78,10 @@ if (await fileExists("README.md")) {
   const readme = readFileSync("README.md", "utf8");
   if (!/\[[^\]]*intended use[^\]]*\]\(docs\/intended-use\.md\)/i.test(readme)) {
     failures.push("README.md must link to docs/intended-use.md with intended-use navigation text.");
+  }
+
+  if (!/\[[^\]]*ERPNext[^\]]*mapping[^\]]*\]\(docs\/erpnext-object-mapping\.md\)/i.test(readme)) {
+    failures.push("README.md must link to docs/erpnext-object-mapping.md with ERPNext mapping navigation text.");
   }
 }
 
@@ -95,6 +100,26 @@ if (await fileExists("docs/intended-use.md")) {
   ]) {
     if (!intendedUse.includes(phrase)) {
       failures.push(`docs/intended-use.md must name the boundary phrase: ${phrase}`);
+    }
+  }
+}
+
+if (await fileExists("docs/erpnext-object-mapping.md")) {
+  const mapping = readFileSync("docs/erpnext-object-mapping.md", "utf8").toLowerCase();
+  for (const phrase of [
+    "draft until validated",
+    "data classification",
+    "future usage",
+    "evidence",
+    "audit",
+    "live erpnext connector",
+    "write-back",
+    "regulated workflow operation",
+    "electronic signature",
+    "compliance guarantee"
+  ]) {
+    if (!mapping.includes(phrase)) {
+      failures.push(`docs/erpnext-object-mapping.md must name the mapping phrase: ${phrase}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add the first ERPNext object mapping draft for future read-only / draft-only Pharma pilot planning
- link the mapping from README navigation
- tighten pre-PR verification so the mapping artifact, README link, and boundary phrases remain present

## Verification
- npm run verify:pre-pr
- manual review for no live ERPNext operation, write-back, electronic signature behavior, regulated workflow operation, or compliance guarantee claims

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive ERPNext object mapping documentation defining draft mapping for pharma/GxP workflow scaffolding, including object-to-concept mappings, field preservation guidance, and validation requirements for future implementation.
  * Updated README to include reference to the new mapping documentation.
  * Enhanced pre-release documentation validation standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->