### PR TITLE
PHARMA-040: Add validation package skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,4 +20,5 @@ CI runs the same command for pull requests and pushes to `main`.
 - `.github/workflows/ci.yml` runs the baseline verification command.
 - The [first pilot intended use and GxP boundary](docs/intended-use.md) document defines the supported scaffolding and out-of-scope regulated operations.
 - The [ERPNext object mapping draft](docs/erpnext-object-mapping.md) identifies candidate source objects, Ensen-flow-pharma concepts, data classification notes, future usage, and evidence/audit implications.
+- The [validation package skeleton](docs/validation-package/README.md) provides draft-only placeholders for validation planning, requirements, risk, traceability, and IQ/OQ/PQ-style evidence planning.
 - `docs/validation-templates/` is reserved for future validation-ready templates and examples.

--- a/docs/validation-package/README.md
+++ b/docs/validation-package/README.md
@@ -1,0 +1,38 @@
+# Validation Package Skeleton
+
+## Purpose
+
+This directory contains draft-only validation package scaffolding for future Ensen-flow-pharma work. It is a planning aid for validation package authors and reviewers, not a validated workflow and not a compliance guarantee.
+
+The skeleton cross-references the pilot intended use, GxP boundary, ERPNext object mapping draft, and future Ensen evidence and audit concepts without adding runtime behavior.
+
+## Package Index
+
+- [Validation plan](validation-plan.md) for scope, roles, controlled placeholders, and approval gates.
+- [User requirements specification](user-requirements-specification.md) for URS placeholders.
+- [Functional specification](functional-specification.md) for design placeholders linked to requirements.
+- [Risk assessment](risk-assessment.md) for draft risk controls and review notes.
+- [Traceability matrix](traceability-matrix.md) for URS, FS, risk, IQ, OQ, and PQ linkage planning.
+- [Installation qualification](installation-qualification.md) for IQ evidence planning.
+- [Operational qualification](operational-qualification.md) for OQ evidence planning.
+- [Performance qualification](performance-qualification.md) for PQ evidence planning.
+
+## Control Points
+
+- Intended use: planning and authoring support for future validation package assets.
+- GxP boundary: no live ERPNext execution, no write-back, and no regulated disposition behavior.
+- Read-only source posture: source references are copied or documented examples only.
+- Draft-only output posture: every artifact remains open placeholders until a qualified process approves it outside this repository.
+- Human approval: regulated use, release decisions, disposition decisions, and quality actions require qualified human approval outside this scaffold.
+- Evidence and audit posture: future evidence and audit fields must distinguish copied source context, reviewer notes, and approval state.
+
+## Open Placeholders
+
+- Validation owner:
+- System owner:
+- Quality owner:
+- Source ERPNext environment:
+- Intended workflow package:
+- Evidence repository:
+- Approval process:
+- Revision history:

--- a/docs/validation-package/functional-specification.md
+++ b/docs/validation-package/functional-specification.md
@@ -1,0 +1,23 @@
+# Functional Specification Skeleton
+
+## Purpose
+
+This functional specification is a draft FS scaffold for future design placeholders. It links future behavior concepts to URS entries, ERPNext mapping context, Ensen evidence concepts, and audit concepts without implementing live workflow execution.
+
+## Functional Placeholder Table
+
+| FS ID | Requirement link | Design placeholder | ERPNext context | Ensen evidence or audit note | Open placeholders |
+| --- | --- | --- | --- | --- | --- |
+| FS-001 | URS-001 | Represent workflow package scope as reviewer-facing documentation | Intended use and GxP boundary | Capture reviewer note and revision reference | Package metadata fields |
+| FS-002 | URS-002 | Represent copied ERPNext object context as read-only source references | ERPNext object mapping draft | Preserve source identifier, timestamp, and provenance note | Object fields and source environment |
+| FS-003 | URS-003 | Mark all generated package assets as draft-only | No regulated workflow operation | Keep approval state separate from draft content | Draft banner and review status |
+| FS-004 | URS-004 | Provide evidence and audit planning fields | Future source evidence only | Distinguish source audit trail from draft review notes | Evidence index and audit note fields |
+
+## Open Placeholders
+
+- Functional author:
+- Design review owner:
+- Interface assumptions:
+- Data assumptions:
+- Rejected alternatives:
+- Verification approach:

--- a/docs/validation-package/installation-qualification.md
+++ b/docs/validation-package/installation-qualification.md
@@ -1,0 +1,22 @@
+# Installation Qualification Skeleton
+
+## Purpose
+
+This installation qualification is a draft IQ evidence planning scaffold. It covers repository and documentation readiness checks only; it does not qualify a production system.
+
+## IQ Placeholder Table
+
+| IQ ID | Prerequisite | Check | Expected result | Evidence placeholder | Open placeholders |
+| --- | --- | --- | --- | --- | --- |
+| IQ-001 | Validation package files exist | Review repo-local validation package directory | Required skeleton files are present | File listing review note | Reviewer and revision |
+| IQ-002 | Intended use is documented | Review intended-use and GxP boundary link | Boundary is clear and draft-only | Document review note | Reviewer and issue reference |
+| IQ-003 | ERPNext mapping is documented | Review ERPNext object mapping draft link | Source context is read-only and non-operational | Mapping review note | Source owner and environment |
+| IQ-004 | Evidence and audit placeholders exist | Review package skeleton fields | Evidence and audit concepts are separated | Checklist review note | Evidence owner and audit owner |
+
+## Open Placeholders
+
+- Installation qualification owner:
+- Repository revision:
+- Review environment:
+- Exceptions:
+- Approval decision:

--- a/docs/validation-package/operational-qualification.md
+++ b/docs/validation-package/operational-qualification.md
@@ -1,0 +1,22 @@
+# Operational Qualification Skeleton
+
+## Purpose
+
+This operational qualification is a draft OQ evidence planning scaffold. It describes future test objective placeholders and acceptance criteria for documentation behavior only.
+
+## OQ Placeholder Table
+
+| OQ ID | Test objective | Acceptance criteria | Evidence placeholder | Open placeholders |
+| --- | --- | --- | --- | --- |
+| OQ-001 | Confirm package scope remains draft-only | Documentation states the package is planning scaffolding only | Scope review result | Reviewer and revision |
+| OQ-002 | Confirm source references remain read-only | ERPNext context is documented without execution or write-back | Source reference review result | Source record and owner |
+| OQ-003 | Confirm human approval checkpoints are explicit | Release, disposition, and quality actions require external qualified approval | Approval checkpoint review result | Approval route |
+| OQ-004 | Confirm evidence and audit fields remain distinct | Evidence source, audit source, and reviewer notes are separate fields | Field review result | Evidence and audit owners |
+
+## Open Placeholders
+
+- Operational qualification owner:
+- Test data assumptions:
+- Test reviewer:
+- Deviations:
+- Retest plan:

--- a/docs/validation-package/performance-qualification.md
+++ b/docs/validation-package/performance-qualification.md
@@ -1,0 +1,22 @@
+# Performance Qualification Skeleton
+
+## Purpose
+
+This performance qualification is a draft PQ evidence planning scaffold. It captures future scenario placeholders for representative package review without claiming production readiness.
+
+## PQ Placeholder Table
+
+| PQ ID | Scenario | Acceptance criteria | Evidence placeholder | Open placeholders |
+| --- | --- | --- | --- | --- |
+| PQ-001 | Reviewer evaluates package scope for a representative workflow | Scope remains aligned with intended use and GxP boundary | Scenario review note | Workflow name and owner |
+| PQ-002 | Reviewer evaluates copied ERPNext object context | Source provenance is explicit and missing provenance blocks use | Source context review note | Source object and environment |
+| PQ-003 | Reviewer evaluates draft output labeling | Output cannot be mistaken for approved regulated evidence | Draft status review note | Status label and approval route |
+| PQ-004 | Reviewer evaluates evidence and audit planning | Evidence and audit notes remain tied to directly linked records | Evidence review note | Record identifiers and review owner |
+
+## Open Placeholders
+
+- Performance qualification owner:
+- Representative scenario:
+- Entry criteria:
+- Exit criteria:
+- Residual gaps:

--- a/docs/validation-package/risk-assessment.md
+++ b/docs/validation-package/risk-assessment.md
@@ -1,0 +1,21 @@
+# Risk Assessment Skeleton
+
+## Purpose
+
+This risk assessment is a draft scaffold for identifying future validation package risks. It does not approve controls or claim that any process is validated.
+
+## Risk Table
+
+| Risk ID | Hazard | Cause | Impact | Control placeholder | Severity | Occurrence | Detectability | Open placeholders |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| RISK-001 | Source provenance is unclear | Copied ERPNext context lacks owner-approved source record | Draft package may rely on unsupported context | Fail closed until source provenance is provided | TBD | TBD | TBD | Source record and owner |
+| RISK-002 | Draft output is mistaken for approved evidence | Review state is unclear | User may overstate validation readiness | Require draft-only status and human approval checkpoint | TBD | TBD | TBD | Draft status field and approval route |
+| RISK-003 | Evidence and audit concepts are conflated | Source audit trail and draft reviewer notes are not separated | Review package may misrepresent record authority | Separate evidence source, audit source, and reviewer notes | TBD | TBD | TBD | Evidence owner and audit owner |
+
+## Open Placeholders
+
+- Risk method:
+- Scoring scale:
+- Risk acceptance owner:
+- Residual risk decision:
+- Review cadence:

--- a/docs/validation-package/traceability-matrix.md
+++ b/docs/validation-package/traceability-matrix.md
@@ -1,0 +1,22 @@
+# Traceability Matrix Skeleton
+
+## Purpose
+
+This traceability matrix is a draft scaffold for linking requirements, functional placeholders, risks, and IQ/OQ/PQ-style evidence planning. It keeps lineage explicit and does not infer coverage from neighboring records.
+
+## Matrix
+
+| URS ID | FS ID | Risk ID | IQ reference | OQ reference | PQ reference | Evidence placeholder | Open placeholders |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| URS-001 | FS-001 | RISK-002 | IQ-001 | OQ-001 | PQ-001 | Scope review record | Owner, revision, review result |
+| URS-002 | FS-002 | RISK-001 | IQ-002 | OQ-002 | PQ-002 | Source provenance review | Source record, extraction note |
+| URS-003 | FS-003 | RISK-002 | IQ-003 | OQ-003 | PQ-003 | Draft-only status review | Draft status and approval route |
+| URS-004 | FS-004 | RISK-003 | IQ-004 | OQ-004 | PQ-004 | Evidence and audit planning review | Evidence source and audit source |
+
+## Open Placeholders
+
+- Traceability owner:
+- Matrix review date:
+- Coverage gaps:
+- Deferred tests:
+- Approval notes:

--- a/docs/validation-package/user-requirements-specification.md
+++ b/docs/validation-package/user-requirements-specification.md
@@ -1,0 +1,22 @@
+# User Requirements Specification Skeleton
+
+## Purpose
+
+This user requirements specification is a draft URS scaffold. It captures open placeholders for future user needs and acceptance planning while preserving read-only, draft-only, and human approval controls.
+
+## URS Table
+
+| Requirement ID | User need | GxP relevance | Acceptance approach | Human approval checkpoint | Open placeholders |
+| --- | --- | --- | --- | --- | --- |
+| URS-001 | Reference intended workflow package scope | TBD | Review against approved intended use | Quality owner approval required | Package name, owner, revision |
+| URS-002 | Reference ERPNext source context without write-back | TBD | Review copied source fields and provenance | System owner approval required | Source object, environment, extraction note |
+| URS-003 | Preserve draft-only validation output state | TBD | Confirm output status is not approved regulated evidence | Validation owner approval required | Draft status, review route |
+| URS-004 | Plan evidence and audit review fields | TBD | Review evidence placeholder completeness | Quality owner approval required | Evidence source, audit source, reviewer note |
+
+## Open Placeholders
+
+- Requirement author:
+- Source process owner:
+- Requirement priority:
+- Acceptance evidence:
+- Review comments:

--- a/docs/validation-package/validation-plan.md
+++ b/docs/validation-package/validation-plan.md
@@ -1,0 +1,41 @@
+# Validation Plan Skeleton
+
+## Purpose
+
+This validation plan is a draft-only scaffold for future Ensen-flow-pharma validation package planning. It defines open placeholders for scope, roles, evidence, audit expectations, and approval gates without asserting validated use.
+
+## Scope
+
+- Intended use: future planning for a Pharma/GxP workflow package that may reference Ensen Flow concepts.
+- GxP boundary: documentation and template scaffolding only.
+- Read-only inputs: copied or documented source context only; no live ERPNext operation or write-back.
+- Draft-only outputs: generated or assembled materials remain drafts until approved through a qualified external process.
+- Human approval: qualified human review is required before any regulated use, release decision, disposition decision, or quality action.
+
+## Responsibilities
+
+| Role | Draft responsibility | Named owner |
+| --- | --- | --- |
+| Validation owner | Own validation plan content and approval route | TBD |
+| System owner | Confirm intended system boundary and source assumptions | TBD |
+| Quality owner | Review GxP boundary and approval expectations | TBD |
+| Technical reviewer | Review evidence and audit placeholders | TBD |
+
+## Evidence And Audit Planning
+
+- Evidence source placeholders:
+- Audit source placeholders:
+- Traceability expectations:
+- Review record expectations:
+- Retention expectations:
+
+## Open Placeholders
+
+- Workflow package name:
+- ERPNext object mapping reference:
+- Ensen evidence concept reference:
+- Ensen audit concept reference:
+- Entry criteria:
+- Exit criteria:
+- Deviation handling:
+- Approval route:

--- a/scripts/verify-pre-pr.mjs
+++ b/scripts/verify-pre-pr.mjs
@@ -52,6 +52,14 @@ function gitCheckIgnore(path) {
   }
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function containsRequiredPhrase(contents, phrase) {
+  return new RegExp(`\\b${escapeRegExp(phrase)}\\b`, "i").test(contents);
+}
+
 const failures = [];
 
 for (const path of requiredFiles) {
@@ -60,12 +68,7 @@ for (const path of requiredFiles) {
   }
 }
 
-for (const sourcePath of [
-  ".github/workflows/ci.yml",
-  "docs/validation-package/README.md",
-  "docs/validation-templates/README.md",
-  "scripts/verify-pre-pr.mjs"
-]) {
+for (const sourcePath of requiredFiles.filter((path) => path !== ".gitignore")) {
   if (gitCheckIgnore(sourcePath)) {
     failures.push(`Source path is unexpectedly ignored by .gitignore: ${sourcePath}`);
   }
@@ -184,7 +187,7 @@ for (const [path, phrases] of validationPackageExpectations) {
 
   const contents = readFileSync(path, "utf8").toLowerCase();
   for (const phrase of phrases) {
-    if (!contents.includes(phrase)) {
+    if (!containsRequiredPhrase(contents, phrase)) {
       failures.push(`${path} must name the validation skeleton phrase: ${phrase}`);
     }
   }

--- a/scripts/verify-pre-pr.mjs
+++ b/scripts/verify-pre-pr.mjs
@@ -8,6 +8,15 @@ const requiredFiles = [
   "README.md",
   "docs/erpnext-object-mapping.md",
   "docs/intended-use.md",
+  "docs/validation-package/README.md",
+  "docs/validation-package/functional-specification.md",
+  "docs/validation-package/installation-qualification.md",
+  "docs/validation-package/operational-qualification.md",
+  "docs/validation-package/performance-qualification.md",
+  "docs/validation-package/risk-assessment.md",
+  "docs/validation-package/traceability-matrix.md",
+  "docs/validation-package/user-requirements-specification.md",
+  "docs/validation-package/validation-plan.md",
   "docs/validation-templates/README.md",
   "package.json",
   "scripts/verify-pre-pr.mjs"
@@ -53,6 +62,7 @@ for (const path of requiredFiles) {
 
 for (const sourcePath of [
   ".github/workflows/ci.yml",
+  "docs/validation-package/README.md",
   "docs/validation-templates/README.md",
   "scripts/verify-pre-pr.mjs"
 ]) {
@@ -61,7 +71,7 @@ for (const sourcePath of [
   }
 }
 
-for (const path of ["README.md", "docs/erpnext-object-mapping.md", "docs/intended-use.md", "docs/validation-templates/README.md"]) {
+for (const path of requiredFiles.filter((path) => path.endsWith(".md"))) {
   if (!(await fileExists(path))) {
     continue;
   }
@@ -82,6 +92,10 @@ if (await fileExists("README.md")) {
 
   if (!/\[[^\]]*ERPNext[^\]]*mapping[^\]]*\]\(docs\/erpnext-object-mapping\.md\)/i.test(readme)) {
     failures.push("README.md must link to docs/erpnext-object-mapping.md with ERPNext mapping navigation text.");
+  }
+
+  if (!/\[[^\]]*validation package[^\]]*\]\(docs\/validation-package\/README\.md\)/i.test(readme)) {
+    failures.push("README.md must link to docs/validation-package/README.md with validation package navigation text.");
   }
 }
 
@@ -120,6 +134,58 @@ if (await fileExists("docs/erpnext-object-mapping.md")) {
   ]) {
     if (!mapping.includes(phrase)) {
       failures.push(`docs/erpnext-object-mapping.md must name the mapping phrase: ${phrase}`);
+    }
+  }
+}
+
+if (await fileExists("docs/validation-package/README.md")) {
+  const packageReadme = readFileSync("docs/validation-package/README.md", "utf8").toLowerCase();
+  for (const phrase of [
+    "validation plan",
+    "user requirements specification",
+    "functional specification",
+    "risk assessment",
+    "traceability matrix",
+    "installation qualification",
+    "operational qualification",
+    "performance qualification",
+    "intended use",
+    "gxp boundary",
+    "erpnext object mapping",
+    "evidence",
+    "audit",
+    "read-only",
+    "draft-only",
+    "human approval",
+    "not a validated workflow",
+    "not a compliance guarantee"
+  ]) {
+    if (!packageReadme.includes(phrase)) {
+      failures.push(`docs/validation-package/README.md must name the validation package phrase: ${phrase}`);
+    }
+  }
+}
+
+const validationPackageExpectations = new Map([
+  ["docs/validation-package/validation-plan.md", ["purpose", "scope", "intended use", "gxp boundary", "read-only", "draft-only", "human approval", "evidence", "audit", "open placeholders"]],
+  ["docs/validation-package/user-requirements-specification.md", ["user requirements specification", "urs", "requirement id", "acceptance approach", "human approval", "draft-only", "open placeholders"]],
+  ["docs/validation-package/functional-specification.md", ["functional specification", "fs", "requirement link", "design placeholder", "erpnext", "ensen evidence", "audit", "open placeholders"]],
+  ["docs/validation-package/risk-assessment.md", ["risk assessment", "risk id", "hazard", "control", "severity", "occurrence", "detectability", "open placeholders"]],
+  ["docs/validation-package/traceability-matrix.md", ["traceability matrix", "urs id", "fs id", "risk id", "iq", "oq", "pq", "open placeholders"]],
+  ["docs/validation-package/installation-qualification.md", ["installation qualification", "iq", "prerequisite", "evidence placeholder", "expected result", "open placeholders"]],
+  ["docs/validation-package/operational-qualification.md", ["operational qualification", "oq", "test objective", "acceptance criteria", "evidence placeholder", "open placeholders"]],
+  ["docs/validation-package/performance-qualification.md", ["performance qualification", "pq", "scenario", "acceptance criteria", "evidence placeholder", "open placeholders"]]
+]);
+
+for (const [path, phrases] of validationPackageExpectations) {
+  if (!(await fileExists(path))) {
+    continue;
+  }
+
+  const contents = readFileSync(path, "utf8").toLowerCase();
+  for (const phrase of phrases) {
+    if (!contents.includes(phrase)) {
+      failures.push(`${path} must name the validation skeleton phrase: ${phrase}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- add a repo-local validation package skeleton with plan, URS, FS, risk, traceability, and IQ/OQ/PQ placeholders
- keep package wording draft-only, read-only, and dependent on external human approval
- extend pre-PR verification to require the skeleton files and README navigation

## Verification
- npm run verify:pre-pr

Closes #5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a validation package documentation framework: draft templates for user requirements, functional spec, validation plan, IQ/OQ/PQ scaffolds, risk assessment, and a traceability matrix.

* **Chores**
  * Strengthened pre-PR checks to require and validate presence of the new validation-package documentation and key scaffold phrases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->