### PR TITLE
PHARMA-X3B-000: Adopt Protocol v0.4.0 Track B boundary

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ CI runs the same command for pull requests and pushes to `main`.
 - `.gitignore` keeps local/generated artifacts out of source control without hiding documentation, validation templates, fixtures, or GitHub workflow files.
 - `.github/workflows/ci.yml` runs the baseline verification command.
 - The [first pilot intended use and GxP boundary](docs/intended-use.md) document defines the supported scaffolding and out-of-scope regulated operations.
+- The [Protocol v0.4.0 Track B boundary](docs/protocol-v0.4.0-track-b-boundary.md) document records the adopted Ensen-protocol snapshot and the pharma-side validation-ready interpretation of customer / regulated evidence vocabulary.
 - The [ERPNext object mapping draft](docs/erpnext-object-mapping.md) identifies candidate source objects, Ensen-flow-pharma concepts, data classification notes, future usage, and evidence/audit implications.
 - The [validation package skeleton](docs/validation-package/README.md) provides draft-only placeholders for validation planning, requirements, risk, traceability, and IQ/OQ/PQ-style evidence planning.
 - `docs/validation-templates/` is reserved for future validation-ready templates and examples.

--- a/docs/protocol-v0.4.0-track-b-boundary.md
+++ b/docs/protocol-v0.4.0-track-b-boundary.md
@@ -1,0 +1,58 @@
+# Protocol v0.4.0 Track B Boundary
+
+## Adopted Snapshot
+
+Ensen-flow-pharma adopts the public Ensen-protocol `v0.4.0` snapshot as the validation-ready reference for the X-Gate 3 Track B customer / regulated evidence boundary.
+
+Source evidence:
+
+- Repository: `TommyKammy/Ensen-protocol`
+- Release tag: `v0.4.0`
+- Release URL: `https://github.com/TommyKammy/Ensen-protocol/releases/tag/v0.4.0`
+- Release commit: `f6c3c5b`
+- Boundary: X-Gate 3 Track B customer / regulated evidence boundary
+
+This file is the pharma-side protocol snapshot surface for the current skeleton. It records adopted semantics without vendoring runtime implementation code, adding a live connector, or claiming production GxP execution.
+
+## Classification Semantics
+
+Track B classification required means customer / regulated evidence references must carry an explicit classification before the reference is accepted as Track B evidence. Missing or unknown classification must block, reject, quarantine, or route a follow-up instead of being inferred from document names, paths, issue text, operator notes, or nearby metadata.
+
+The pharma validation-ready boundary recognizes these Protocol `v0.4.0` values:
+
+| Value | Pharma-side interpretation |
+| --- | --- |
+| `public` | Synthetic examples, documentation, conformance notes, and validation-ready skeleton text that are safe to publish. |
+| `internal` | Non-public operator or planning evidence that is not customer-owned and not regulated. |
+| `customer-confidential` | Customer-owned, customer-identifying, customer-provided, or customer-system-derived reference material. |
+| `regulated` | Evidence or data subject to regulated handling, retention, validation, electronic record, privacy, or domain-specific controls. |
+
+Public examples in this repository must remain synthetic and use `public` semantics. The repository must add no customer records, no regulated record payloads, no raw secrets, no credentials, no workstation-local absolute paths, no private repository details, and no live connector details to public fixtures, examples, prompts, tests, or documentation.
+
+## Approval and Draft-Only Semantics
+
+Protocol `v0.4.0` approval and draft-only evidence semantics are validation-ready vocabulary for future package authors and reviewers. They do not make this repository an approval engine or production regulated workflow.
+
+The pharma boundary recognizes these approval states:
+
+| Value | Pharma-side interpretation |
+| --- | --- |
+| `approval-required` | A human approval point is required before an action can be committed or externally applied. |
+| `approved` | The authoritative workflow boundary has recorded the required human approval. |
+| `rejected` | The proposed action or evidence must not be treated as approved or applied. |
+| `revoked` | A previously recorded approval was withdrawn by the authoritative workflow boundary. |
+| `superseded` | A newer proposal, approval record, or evidence record replaces this one for future handling. |
+
+A draft-only artifact must stay visibly separate from committed or externally applied evidence. It should name the draft-only intent, the not-applied external state, the approval state, and the human approval boundary. Approval must not be inferred from nearby names, issue text, file shape, notification delivery, or validation-template presence.
+
+## Pharma Boundary
+
+This intake preserves the Ensen-flow-pharma repository boundary:
+
+- It is validation-ready scaffolding, not a production GxP execution claim.
+- It is not a compliance guarantee.
+- It is not Part 11 or Annex 11 assurance.
+- It does not add live ERPNext operation, write-back behavior, electronic signatures, batch release, final disposition, automated quality decisions, credential handling, customer data storage, regulated workflow controls, retention storage, or production audit storage.
+- It does not certify a regulated workflow, package, template, connector, or evidence repository.
+
+Future work may use this vocabulary to shape validation package placeholders, review checklists, and evidence planning. Any runtime handling of customer-confidential or regulated material still needs an explicit owner-controlled boundary, authorization model, storage and retention design, human review process, and validation evidence outside this skeleton.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,15 @@
+{
+  "name": "ensen-flow-pharma",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ensen-flow-pharma",
+      "version": "0.0.0",
+      "engines": {
+        "node": ">=22"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -5,6 +5,8 @@
   "description": "Validation-ready Pharma/GxP workflow scaffolding for Ensen Flow.",
   "type": "module",
   "scripts": {
+    "build": "npm run verify:pre-pr",
+    "test": "npm run verify:pre-pr",
     "verify:pre-pr": "node scripts/verify-pre-pr.mjs"
   },
   "engines": {

--- a/scripts/verify-pre-pr.mjs
+++ b/scripts/verify-pre-pr.mjs
@@ -8,6 +8,7 @@ const requiredFiles = [
   "README.md",
   "docs/erpnext-object-mapping.md",
   "docs/intended-use.md",
+  "docs/protocol-v0.4.0-track-b-boundary.md",
   "docs/validation-package/README.md",
   "docs/validation-package/functional-specification.md",
   "docs/validation-package/installation-qualification.md",
@@ -100,6 +101,10 @@ if (await fileExists("README.md")) {
   if (!/\[[^\]]*validation package[^\]]*\]\(docs\/validation-package\/README\.md\)/i.test(readme)) {
     failures.push("README.md must link to docs/validation-package/README.md with validation package navigation text.");
   }
+
+  if (!/\[[^\]]*Protocol v0\.4\.0[^\]]*\]\(docs\/protocol-v0\.4\.0-track-b-boundary\.md\)/i.test(readme)) {
+    failures.push("README.md must link to docs/protocol-v0.4.0-track-b-boundary.md with Protocol v0.4.0 navigation text.");
+  }
 }
 
 if (await fileExists("docs/intended-use.md")) {
@@ -137,6 +142,44 @@ if (await fileExists("docs/erpnext-object-mapping.md")) {
   ]) {
     if (!mapping.includes(phrase)) {
       failures.push(`docs/erpnext-object-mapping.md must name the mapping phrase: ${phrase}`);
+    }
+  }
+}
+
+if (await fileExists("docs/protocol-v0.4.0-track-b-boundary.md")) {
+  const protocolBoundary = readFileSync("docs/protocol-v0.4.0-track-b-boundary.md", "utf8");
+  const lowerProtocolBoundary = protocolBoundary.toLowerCase();
+
+  for (const phrase of [
+    "ensen-protocol",
+    "v0.4.0",
+    "f6c3c5b",
+    "x-gate 3 track b",
+    "customer / regulated evidence boundary",
+    "public",
+    "internal",
+    "customer-confidential",
+    "regulated",
+    "classification required",
+    "missing or unknown classification",
+    "approval-required",
+    "approved",
+    "rejected",
+    "revoked",
+    "superseded",
+    "draft-only",
+    "human approval",
+    "not-applied",
+    "not a production gxp execution claim",
+    "not a compliance guarantee",
+    "not part 11 or annex 11 assurance",
+    "no customer records",
+    "no regulated record payloads",
+    "no raw secrets",
+    "no live connector details"
+  ]) {
+    if (!lowerProtocolBoundary.includes(phrase)) {
+      failures.push(`docs/protocol-v0.4.0-track-b-boundary.md must name the Protocol v0.4.0 boundary phrase: ${phrase}`);
     }
   }
 }


### PR DESCRIPTION
## Summary
- record Ensen-protocol v0.4.0 / f6c3c5b as the pharma-side Track B evidence boundary snapshot
- document Track B classification, approval, draft-only, and pharma non-claim semantics
- tighten repo-owned verification so the Protocol v0.4.0 boundary doc and README navigation are required
- add build/test script aliases and package-lock from npm install

## Focused reproduction
After tightening the verifier and before adding the doc, npm run verify:pre-pr failed with:
- Missing required baseline file: docs/protocol-v0.4.0-track-b-boundary.md
- README.md must link to docs/protocol-v0.4.0-track-b-boundary.md with Protocol v0.4.0 navigation text.

## Verification
- npm install
- npm run build
- npm test
- npm run verify:pre-pr

Closes #10