### PR TITLE
PHARMA-X3B-002: Add regulated-content artifact safety guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ CI runs the same command for pull requests and pushes to `main`.
 - `.github/workflows/ci.yml` runs the baseline verification command.
 - The [first pilot intended use and GxP boundary](docs/intended-use.md) document defines the supported scaffolding, customer-confidential and regulated input planning boundary, and out-of-scope regulated operations.
 - The [Protocol v0.4.0 Track B boundary](docs/protocol-v0.4.0-track-b-boundary.md) document records the adopted Ensen-protocol snapshot and the pharma-side validation-ready interpretation of customer / regulated evidence vocabulary.
+- The [regulated-content artifact safety](docs/artifact-safety.md) guidance defines synthetic-only public examples, confidential-reference boundaries, and fail-closed handling for unsafe public artifacts.
 - The [ERPNext object mapping draft](docs/erpnext-object-mapping.md) identifies candidate source objects, Ensen-flow-pharma concepts, data classification notes, future usage, and evidence/audit implications.
 - The [validation package skeleton](docs/validation-package/README.md) provides draft-only placeholders for validation planning, requirements, risk, traceability, and IQ/OQ/PQ-style evidence planning.
 - `docs/validation-templates/` is reserved for future validation-ready templates and examples.

--- a/docs/artifact-safety.md
+++ b/docs/artifact-safety.md
@@ -1,0 +1,66 @@
+# Regulated-Content Artifact Safety
+
+## Purpose
+
+Artifact safety defines what may appear in public Ensen-flow-pharma documentation, validation package assets, validation templates, examples, prompts, tests, and fixtures.
+
+This repository is public validation-ready scaffolding. It may describe customer-confidential and regulated handling boundaries, but public artifacts must use synthetic-only public examples and must not publish raw customer, regulated, secret, or environment-specific content.
+
+## Public Artifact Boundary
+
+Public artifacts may include:
+
+- Synthetic-only public examples that are invented for documentation or validation-template shape.
+- Public Ensen-protocol references and public Protocol v0.4.0 Track B vocabulary.
+- Draft-only validation package placeholders that name intended fields without real source payloads.
+- Generic role names, generic system labels, and placeholder identifiers that cannot identify a customer, patient, batch, regulated record, source tenant, private repository, or live environment.
+
+Public artifacts must not include:
+
+- Raw customer data or customer-owned records.
+- Raw regulated records, regulated record payloads, batch records, disposition records, complaint records, deviation records, audit records, electronic signatures, or production evidence.
+- Raw credentials, raw secrets, tokens, private keys, passwords, connection strings, API keys, or sample values that resemble reusable credentials.
+- Workstation-local absolute paths, user-home paths, private file shares, or host-specific local evidence locations.
+- Live connector details, source tenant names, private repository URLs, real ERPNext site details, live environment names, network endpoints, or account identifiers.
+- Customer identifiers, patient identifiers, user identifiers, tenant identifiers, batch identifiers, product identifiers, or source object IDs taken from real systems.
+
+If an artifact needs to show shape, use placeholders such as `<customer-id>`, `<regulated-record-id>`, `<erpnext-site>`, `<evidence-reference>`, or `<supervisor-config-path>` instead of real values.
+
+## Confidential References
+
+Customer-confidential or regulated context belongs outside public artifacts unless it has been transformed into a synthetic example. Confidential references may be tracked only in owner-controlled local systems or future approved evidence repositories with explicit authorization, retention, access control, and review boundaries.
+
+The public repository may point to the existence of a confidential reference boundary, but it must not contain the raw confidential reference itself. Do not move customer-confidential, regulated, or secret material into public Markdown, validation templates, examples, prompts, tests, fixtures, issue text, pull request text, screenshots, exported logs, or committed evidence files.
+
+## Protocol v0.4.0 Track B Alignment
+
+Protocol v0.4.0 Track B classification separates `public`, `internal`, `customer-confidential`, and `regulated` contexts. Ensen-flow-pharma uses that classification vocabulary as planning guidance:
+
+- `public` is the only classification allowed for committed public examples in this repository.
+- `customer-confidential` and `regulated` examples must be synthetic before publication.
+- Missing, unclear, or unknown classification must fail closed instead of being inferred from document names, path shape, issue text, or nearby notes.
+- Approval, draft-only, and evidence vocabulary does not turn this repository into a production GxP system, compliance guarantee, or approved evidence store.
+
+## Fail-Closed Workflow Boundary
+
+Before publishing or committing an artifact, reviewers and future automation must reject the artifact or route it for private remediation when it contains, appears to contain, or cannot prove the absence of unsafe regulated-content categories.
+
+Unsafe categories fail closed:
+
+| Category | Public artifact handling |
+| --- | --- |
+| Raw customer data | Do not publish; replace with synthetic-only public examples. |
+| Raw regulated records | Do not publish; keep outside the public repository and use placeholders. |
+| Raw credentials or raw secrets | Do not publish; rotate if exposure is possible and remove from artifacts. |
+| Workstation-local absolute paths | Do not publish; replace with repo-relative commands or placeholders. |
+| Live connector details | Do not publish; describe connector shape without real tenant, endpoint, or account details. |
+| Customer identifiers | Do not publish; replace with synthetic labels or placeholders. |
+| Missing or unknown classification | Do not publish; classify through the authoritative boundary first. |
+
+This fail-closed guidance applies to README updates, validation package documents, validation templates, examples, prompts, tests, fixtures, generated outputs, exported logs, review attachments, and any future artifact proposed for publication.
+
+## Validation Package and Template Guidance
+
+Validation package and validation templates assets should show field structure, review expectations, and placeholder evidence references without embedding raw source content. Use synthetic examples for package shape and reserve confidential references for owner-controlled systems outside this public repository.
+
+Validation authors should document where a confidential reference would be controlled, who owns review, and which approval or evidence boundary would apply. They must not include the actual confidential reference, regulated record, secret, live connector detail, or customer identifier in the public artifact.

--- a/docs/validation-package/README.md
+++ b/docs/validation-package/README.md
@@ -4,7 +4,7 @@
 
 This directory contains draft-only validation package scaffolding for future Ensen-flow-pharma work. It is a planning aid for validation package authors and reviewers, not a validated workflow and not a compliance guarantee.
 
-The skeleton cross-references the pilot intended use, GxP boundary, ERPNext object mapping draft, and future Ensen evidence and audit concepts without adding runtime behavior.
+The skeleton cross-references the pilot intended use, GxP boundary, ERPNext object mapping draft, artifact safety guidance, and future Ensen evidence and audit concepts without adding runtime behavior.
 
 ## Package Index
 
@@ -16,6 +16,7 @@ The skeleton cross-references the pilot intended use, GxP boundary, ERPNext obje
 - [Installation qualification](installation-qualification.md) for IQ evidence planning.
 - [Operational qualification](operational-qualification.md) for OQ evidence planning.
 - [Performance qualification](performance-qualification.md) for PQ evidence planning.
+- [Regulated-content artifact safety](../artifact-safety.md) for synthetic-only public examples and confidential-reference boundaries.
 
 ## Control Points
 
@@ -25,6 +26,7 @@ The skeleton cross-references the pilot intended use, GxP boundary, ERPNext obje
 - Draft-only output posture: every artifact remains open placeholders until a qualified process approves it outside this repository.
 - Human approval: regulated use, release decisions, disposition decisions, and quality actions require qualified human approval outside this scaffold.
 - Evidence and audit posture: future evidence and audit fields must distinguish copied source context, reviewer notes, and approval state.
+- Artifact safety: public validation package examples must stay synthetic-only public examples; raw customer data, raw regulated records, raw credentials, raw secrets, workstation-local absolute paths, live connector details, and customer identifiers fail closed and stay out of committed public artifacts.
 
 ## Open Placeholders
 

--- a/docs/validation-templates/README.md
+++ b/docs/validation-templates/README.md
@@ -4,4 +4,4 @@ This directory is reserved for validation-ready templates and examples that futu
 
 The repo baseline does not provide live ERPNext integration, regulated workflow execution, electronic signatures, write-back behavior, batch release, final disposition, or automated quality decisions.
 
-Future templates should keep evidence fields explicit, distinguish draft examples from approved records, and avoid embedding credentials or environment-specific secrets.
+Future templates should follow the [regulated-content artifact safety](../artifact-safety.md) guidance: keep evidence fields explicit, use synthetic-only public examples, distinguish draft examples from approved records, and avoid embedding customer data, regulated records, credentials, environment-specific secrets, workstation-local paths, live connector details, or customer identifiers.

--- a/scripts/verify-pre-pr.mjs
+++ b/scripts/verify-pre-pr.mjs
@@ -6,6 +6,7 @@ const requiredFiles = [
   ".gitignore",
   ".github/workflows/ci.yml",
   "README.md",
+  "docs/artifact-safety.md",
   "docs/erpnext-object-mapping.md",
   "docs/intended-use.md",
   "docs/protocol-v0.4.0-track-b-boundary.md",
@@ -105,6 +106,10 @@ if (await fileExists("README.md")) {
   if (!/\[[^\]]*Protocol v0\.4\.0[^\]]*\]\(docs\/protocol-v0\.4\.0-track-b-boundary\.md\)/i.test(readme)) {
     failures.push("README.md must link to docs/protocol-v0.4.0-track-b-boundary.md with Protocol v0.4.0 navigation text.");
   }
+
+  if (!/\[[^\]]*artifact safety[^\]]*\]\(docs\/artifact-safety\.md\)/i.test(readme)) {
+    failures.push("README.md must link to docs/artifact-safety.md with artifact safety navigation text.");
+  }
 }
 
 if (await fileExists("docs/intended-use.md")) {
@@ -194,6 +199,34 @@ if (await fileExists("docs/protocol-v0.4.0-track-b-boundary.md")) {
   }
 }
 
+if (await fileExists("docs/artifact-safety.md")) {
+  const artifactSafety = readFileSync("docs/artifact-safety.md", "utf8").toLowerCase();
+  for (const phrase of [
+    "artifact safety",
+    "synthetic-only public examples",
+    "confidential references",
+    "customer-confidential",
+    "regulated",
+    "protocol v0.4.0 track b",
+    "public",
+    "raw customer data",
+    "raw regulated records",
+    "raw credentials",
+    "raw secrets",
+    "workstation-local absolute paths",
+    "live connector details",
+    "customer identifiers",
+    "fail closed",
+    "do not publish",
+    "validation package",
+    "validation templates"
+  ]) {
+    if (!artifactSafety.includes(phrase)) {
+      failures.push(`docs/artifact-safety.md must name the artifact safety phrase: ${phrase}`);
+    }
+  }
+}
+
 if (await fileExists("docs/validation-package/README.md")) {
   const packageReadme = readFileSync("docs/validation-package/README.md", "utf8").toLowerCase();
   for (const phrase of [
@@ -213,6 +246,8 @@ if (await fileExists("docs/validation-package/README.md")) {
     "read-only",
     "draft-only",
     "human approval",
+    "artifact safety",
+    "synthetic-only public examples",
     "not a validated workflow",
     "not a compliance guarantee"
   ]) {


### PR DESCRIPTION
## Summary
- add regulated-content artifact safety guidance for public documentation and validation artifacts
- require synthetic-only public examples and confidential-reference separation
- tighten pre-PR verification so README and validation package navigation cover artifact safety

## Verification
- npm run verify:pre-pr
- npm test
- npm run build
- git diff --check
- manual rg scan for workstation-local paths and credential-like literals

Refs #12