### PR TITLE
PHARMA-X3B-003: Define regulated workflow controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ CI runs the same command for pull requests and pushes to `main`.
 - The [first pilot intended use and GxP boundary](docs/intended-use.md) document defines the supported scaffolding, customer-confidential and regulated input planning boundary, and out-of-scope regulated operations.
 - The [Protocol v0.4.0 Track B boundary](docs/protocol-v0.4.0-track-b-boundary.md) document records the adopted Ensen-protocol snapshot and the pharma-side validation-ready interpretation of customer / regulated evidence vocabulary.
 - The [regulated-content artifact safety](docs/artifact-safety.md) guidance defines synthetic-only public examples, confidential-reference boundaries, and fail-closed handling for unsafe public artifacts.
+- The [regulated workflow controls](docs/regulated-workflow-controls.md) document defines read-only input controls, draft-only output controls, human approval checkpoints, and non-goals for automatic quality decisions or regulated write-back.
 - The [ERPNext object mapping draft](docs/erpnext-object-mapping.md) identifies candidate source objects, Ensen-flow-pharma concepts, data classification notes, future usage, and evidence/audit implications.
 - The [validation package skeleton](docs/validation-package/README.md) provides draft-only placeholders for validation planning, requirements, risk, traceability, and IQ/OQ/PQ-style evidence planning.
 - `docs/validation-templates/` is reserved for future validation-ready templates and examples.

--- a/docs/regulated-workflow-controls.md
+++ b/docs/regulated-workflow-controls.md
@@ -1,0 +1,63 @@
+# Regulated Workflow Controls
+
+## Purpose
+
+This document defines the read-only input controls and draft-only output controls for Ensen-flow-pharma Track B planning. It keeps future workflow package authors, validation package authors, and reviewers aligned on the current repository boundary: documentation and validation-ready scaffolding only.
+
+These controls do not implement runtime regulated workflow execution, live ERPNext integration, or an approval engine. They describe what future packages must preserve before any owner-controlled validated process can use generated material.
+
+## Read-Only Input Controls
+
+Input context in this repository is read-only planning context. Public artifacts may describe or reference only these input shapes:
+
+| Input shape | Control |
+| --- | --- |
+| Copied context | Treat copied source context as a static planning reference. Do not mutate, synchronize, or write back to the source system. |
+| Exported context | Treat exported source context as a detached snapshot. Do not claim the export is current, complete, validated, or authoritative for regulated use. |
+| Fake context | Use synthetic fake examples for public documentation, tests, prompts, fixtures, and templates. Do not mix fake examples with customer-confidential or regulated records. |
+| Reference-only context | Use references to describe intended linkage or evidence shape. Do not treat a reference as approval, source truth, release authorization, or a regulated record. |
+
+Missing provenance, unclear classification, untrusted identity, placeholder credentials, TODO values, unsigned tokens, copied host hints, or inferred tenant, repository, batch, account, issue, or environment linkage must fail closed. The repository must not infer regulated readiness from document names, path shape, nearby notes, GitHub issue text, or validation-template presence.
+
+Read-only input controls prohibit live write-back, live connector operation, direct ERPNext mutation, source-record updates, customer-system updates, and any automated external application of generated material.
+
+## Draft-Only Output Controls
+
+Generated or assembled output remains draft-only until a separate qualified process reviews and approves it outside this public scaffold. Draft-only output controls apply to:
+
+- Workflow package assets.
+- Validation package deltas.
+- Validation plan, URS, FS, risk, traceability, IQ, OQ, and PQ placeholders.
+- Evidence and audit planning notes.
+- Review checklists, prompts, examples, and templates.
+
+Draft artifacts must stay visibly separate from committed, applied, approved, released, or dispositioned records. A draft may name intended evidence fields, approval routes, and source assumptions, but it must not present itself as validated evidence, an approved quality record, a completed batch release, a final disposition, or a production GxP workflow.
+
+## Human Approval Checkpoints
+
+Human approval checkpoints are mandatory and separate from generated draft artifacts. A qualified human approval checkpoint is required before:
+
+- Regulated use.
+- Release decision.
+- Disposition decision.
+- Quality action.
+- External application of a workflow package asset.
+- Acceptance of validation package deltas into a controlled validation package.
+
+The human approval checkpoint must be recorded by the authoritative owner-controlled process. Approval must not be inferred from generated text, notification delivery, issue state, pull request state, file presence, template completion, copied comments, or convenience summaries.
+
+## Non-Goals
+
+These behaviors are explicitly out of scope for this repository:
+
+- Automatic quality decisions.
+- Automatic release.
+- Automatic disposition.
+- Batch release approval.
+- Final disposition approval.
+- Live write-back to ERPNext or any other source system.
+- Electronic signatures.
+- Runtime regulated workflow execution.
+- Part 11, Annex 11, GxP validation, or compliance guarantees.
+
+Future implementation work must preserve this boundary unless a later issue adds a validated, owner-controlled runtime design with explicit authorization, provenance, retention, human review, evidence, audit, and validation controls.

--- a/docs/validation-package/README.md
+++ b/docs/validation-package/README.md
@@ -17,6 +17,7 @@ The skeleton cross-references the pilot intended use, GxP boundary, ERPNext obje
 - [Operational qualification](operational-qualification.md) for OQ evidence planning.
 - [Performance qualification](performance-qualification.md) for PQ evidence planning.
 - [Regulated-content artifact safety](../artifact-safety.md) for synthetic-only public examples and confidential-reference boundaries.
+- [Regulated workflow controls](../regulated-workflow-controls.md) for read-only input controls, draft-only output controls, human approval checkpoints, and non-goals for automatic quality decision behavior.
 
 ## Control Points
 
@@ -25,6 +26,8 @@ The skeleton cross-references the pilot intended use, GxP boundary, ERPNext obje
 - Read-only source posture: source references are copied or documented examples only.
 - Draft-only output posture: every artifact remains open placeholders until a qualified process approves it outside this repository.
 - Human approval: regulated use, release decisions, disposition decisions, and quality actions require qualified human approval outside this scaffold.
+- Regulated workflow controls: validation package deltas remain draft-only outputs, source context remains under read-only input controls, and human approval checkpoints must be explicit before any controlled validation package use.
+- Automatic quality decision boundary: generated validation package assets must not claim automatic quality decisions, automatic release, automatic disposition, live write-back, or electronic signatures.
 - Evidence and audit posture: future evidence and audit fields must distinguish copied source context, reviewer notes, and approval state.
 - Artifact safety: public validation package examples must stay synthetic-only public examples; raw customer data, raw regulated records, raw credentials, raw secrets, workstation-local absolute paths, live connector details, and customer identifiers fail closed and stay out of committed public artifacts.
 

--- a/docs/validation-package/validation-plan.md
+++ b/docs/validation-package/validation-plan.md
@@ -8,9 +8,11 @@ This validation plan is a draft-only scaffold for future Ensen-flow-pharma valid
 
 - Intended use: future planning for a Pharma/GxP workflow package that may reference Ensen Flow concepts.
 - GxP boundary: documentation and template scaffolding only.
+- Regulated workflow controls: read-only source context and draft-only generated assets remain separate from any controlled validation package.
 - Read-only inputs: copied or documented source context only; no live ERPNext operation or write-back.
 - Draft-only outputs: generated or assembled materials remain drafts until approved through a qualified external process.
-- Human approval: qualified human review is required before any regulated use, release decision, disposition decision, or quality action.
+- Human approval: a qualified human approval checkpoint is required before any regulated use, release decision, disposition decision, quality action, or acceptance of validation package deltas into a controlled package.
+- Automatic quality decision boundary: this plan does not support automatic quality decision behavior, automatic release, automatic disposition, live write-back, or electronic signatures.
 
 ## Responsibilities
 

--- a/scripts/verify-pre-pr.mjs
+++ b/scripts/verify-pre-pr.mjs
@@ -10,6 +10,7 @@ const requiredFiles = [
   "docs/erpnext-object-mapping.md",
   "docs/intended-use.md",
   "docs/protocol-v0.4.0-track-b-boundary.md",
+  "docs/regulated-workflow-controls.md",
   "docs/validation-package/README.md",
   "docs/validation-package/functional-specification.md",
   "docs/validation-package/installation-qualification.md",
@@ -109,6 +110,10 @@ if (await fileExists("README.md")) {
 
   if (!/\[[^\]]*artifact safety[^\]]*\]\(docs\/artifact-safety\.md\)/i.test(readme)) {
     failures.push("README.md must link to docs/artifact-safety.md with artifact safety navigation text.");
+  }
+
+  if (!/\[[^\]]*regulated workflow controls[^\]]*\]\(docs\/regulated-workflow-controls\.md\)/i.test(readme)) {
+    failures.push("README.md must link to docs/regulated-workflow-controls.md with regulated workflow controls navigation text.");
   }
 }
 
@@ -227,6 +232,36 @@ if (await fileExists("docs/artifact-safety.md")) {
   }
 }
 
+if (await fileExists("docs/regulated-workflow-controls.md")) {
+  const regulatedWorkflowControls = readFileSync("docs/regulated-workflow-controls.md", "utf8").toLowerCase();
+  for (const phrase of [
+    "regulated workflow controls",
+    "read-only input controls",
+    "copied",
+    "exported",
+    "fake",
+    "reference-only",
+    "draft-only output controls",
+    "workflow package assets",
+    "validation package deltas",
+    "human approval checkpoint",
+    "regulated use",
+    "release decision",
+    "disposition decision",
+    "quality action",
+    "automatic quality decisions",
+    "automatic release",
+    "automatic disposition",
+    "live write-back",
+    "electronic signatures",
+    "non-goals"
+  ]) {
+    if (!regulatedWorkflowControls.includes(phrase)) {
+      failures.push(`docs/regulated-workflow-controls.md must name the regulated workflow control phrase: ${phrase}`);
+    }
+  }
+}
+
 if (await fileExists("docs/validation-package/README.md")) {
   const packageReadme = readFileSync("docs/validation-package/README.md", "utf8").toLowerCase();
   for (const phrase of [
@@ -246,6 +281,11 @@ if (await fileExists("docs/validation-package/README.md")) {
     "read-only",
     "draft-only",
     "human approval",
+    "regulated workflow controls",
+    "read-only input controls",
+    "draft-only output controls",
+    "human approval checkpoints",
+    "automatic quality decision",
     "artifact safety",
     "synthetic-only public examples",
     "not a validated workflow",
@@ -258,7 +298,7 @@ if (await fileExists("docs/validation-package/README.md")) {
 }
 
 const validationPackageExpectations = new Map([
-  ["docs/validation-package/validation-plan.md", ["purpose", "scope", "intended use", "gxp boundary", "read-only", "draft-only", "human approval", "evidence", "audit", "open placeholders"]],
+  ["docs/validation-package/validation-plan.md", ["purpose", "scope", "intended use", "gxp boundary", "regulated workflow controls", "read-only", "draft-only", "human approval", "human approval checkpoint", "automatic quality decision", "evidence", "audit", "open placeholders"]],
   ["docs/validation-package/user-requirements-specification.md", ["user requirements specification", "urs", "requirement id", "acceptance approach", "human approval", "draft-only", "open placeholders"]],
   ["docs/validation-package/functional-specification.md", ["functional specification", "fs", "requirement link", "design placeholder", "erpnext", "ensen evidence", "audit", "open placeholders"]],
   ["docs/validation-package/risk-assessment.md", ["risk assessment", "risk id", "hazard", "control", "severity", "occurrence", "detectability", "open placeholders"]],


### PR DESCRIPTION
## Summary
- add repo-local regulated workflow controls for read-only inputs and draft-only outputs
- document required human approval checkpoints and regulated workflow non-goals
- reference the boundary from README and validation package skeleton
- tighten pre-PR verification so the boundary remains covered

Closes #13

## Verification
- npm run verify:pre-pr