### PR TITLE
PHARMA-X3B-004: Add Track B validation package delta

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,4 +24,5 @@ CI runs the same command for pull requests and pushes to `main`.
 - The [regulated workflow controls](docs/regulated-workflow-controls.md) document defines read-only input controls, draft-only output controls, human approval checkpoints, and non-goals for automatic quality decisions or regulated write-back.
 - The [ERPNext object mapping draft](docs/erpnext-object-mapping.md) identifies candidate source objects, Ensen-flow-pharma concepts, data classification notes, future usage, and evidence/audit implications.
 - The [validation package skeleton](docs/validation-package/README.md) provides draft-only placeholders for validation planning, requirements, risk, traceability, and IQ/OQ/PQ-style evidence planning.
+- The [Track B validation delta](docs/validation-package/track-b-validation-delta.md) adds draft-only placeholders for customer-confidential and regulated input boundary planning.
 - `docs/validation-templates/` is reserved for future validation-ready templates and examples.

--- a/docs/validation-package/README.md
+++ b/docs/validation-package/README.md
@@ -12,6 +12,7 @@ The skeleton cross-references the pilot intended use, GxP boundary, ERPNext obje
 - [User requirements specification](user-requirements-specification.md) for URS placeholders.
 - [Functional specification](functional-specification.md) for design placeholders linked to requirements.
 - [Risk assessment](risk-assessment.md) for draft risk controls and review notes.
+- [Track B validation delta](track-b-validation-delta.md) for customer-confidential and regulated input boundary placeholders, source provenance, classification, confidential references, draft status, human approval, evidence retention, rollback / revocation, and residual risk planning.
 - [Traceability matrix](traceability-matrix.md) for URS, FS, risk, IQ, OQ, and PQ linkage planning.
 - [Installation qualification](installation-qualification.md) for IQ evidence planning.
 - [Operational qualification](operational-qualification.md) for OQ evidence planning.
@@ -26,6 +27,7 @@ The skeleton cross-references the pilot intended use, GxP boundary, ERPNext obje
 - Read-only source posture: source references are copied or documented examples only.
 - Draft-only output posture: every artifact remains open placeholders until a qualified process approves it outside this repository.
 - Human approval: regulated use, release decisions, disposition decisions, and quality actions require qualified human approval outside this scaffold.
+- Track B validation delta: customer-confidential and regulated input boundary fields remain open placeholders for intended-use-specific validation planning.
 - Regulated workflow controls: validation package deltas remain draft-only outputs, source context remains under read-only input controls, and human approval checkpoints must be explicit before any controlled validation package use.
 - Automatic quality decision boundary: generated validation package assets must not claim automatic quality decisions, automatic release, automatic disposition, live write-back, or electronic signatures.
 - Evidence and audit posture: future evidence and audit fields must distinguish copied source context, reviewer notes, and approval state.
@@ -41,3 +43,4 @@ The skeleton cross-references the pilot intended use, GxP boundary, ERPNext obje
 - Evidence repository:
 - Approval process:
 - Revision history:
+- Track B validation delta owner:

--- a/docs/validation-package/track-b-validation-delta.md
+++ b/docs/validation-package/track-b-validation-delta.md
@@ -1,0 +1,58 @@
+# Track B Validation Delta
+
+## Purpose
+
+This Track B validation delta extends the Phase 1 validation package skeleton with open placeholders for customer-confidential and regulated input boundaries.
+
+The delta is draft-only validation planning material. It is not a validated workflow, not a compliance guarantee, not an ERPNext operation, and not evidence that any workflow package is ready for regulated execution.
+
+## Boundary References
+
+- Intended use: see [First Pilot Intended Use and GxP Boundary](../intended-use.md).
+- Artifact safety: see [Regulated-Content Artifact Safety](../artifact-safety.md).
+- Workflow controls: see [Regulated Workflow Controls](../regulated-workflow-controls.md).
+- Protocol boundary: see [Protocol v0.4.0 Track B boundary](../protocol-v0.4.0-track-b-boundary.md).
+
+This delta keeps Track B material under read-only input controls and draft-only output controls. A qualified human approval checkpoint outside this repository is required before any controlled validation package use.
+
+## Customer / Regulated Boundary Placeholders
+
+| Placeholder | Draft value |
+| --- | --- |
+| Source provenance | `<source-provenance-placeholder>` |
+| Data classification | `<public-or-internal-or-customer-confidential-or-regulated>` |
+| Confidential reference | `<owner-controlled-confidential-reference>` |
+| Draft status | `<draft-status-placeholder>` |
+| Human approval | `<qualified-human-approval-placeholder>` |
+| Evidence retention | `<evidence-retention-placeholder>` |
+| Rollback / revocation | `<rollback-or-revocation-placeholder>` |
+| Residual risk | `<residual-risk-notes-placeholder>` |
+
+## Placeholder Guidance
+
+- Source provenance must identify the future authoritative source boundary without embedding raw customer data, raw regulated records, live connector details, workstation-local absolute paths, credentials, secrets, or production evidence.
+- Data classification must be explicit before use. Missing, unknown, or inferred classification fails closed and remains outside the public validation package.
+- Confidential reference values must point only to owner-controlled systems or future approved evidence repositories. The public artifact must not contain the raw confidential reference.
+- Draft status must remain visible until a separate qualified process accepts the material into a controlled validation package.
+- Human approval must be recorded by the authoritative owner-controlled process. Approval must not be inferred from issue state, pull request state, generated text, template completion, or file presence.
+- Evidence retention placeholders must name the intended retention boundary without claiming that this repository is an approved evidence store.
+- Rollback / revocation placeholders must describe how a future owner-controlled process would withdraw, supersede, or revoke the draft delta if its scope, provenance, approval, or classification changes.
+- Residual risk notes must stay open until the intended-use-specific validation plan, risk assessment, and traceability matrix are reviewed by qualified owners.
+
+## Out-of-Scope Claims
+
+This delta does not add or authorize customer SOP execution, live ERPNext operation, source-system write-back, electronic signatures, batch release, final disposition, automated quality decisions, validation execution, Part 11 assurance, Annex 11 assurance, or GxP compliance guarantees.
+
+## Open Placeholders
+
+- Validation owner:
+- Quality owner:
+- Intended workflow package:
+- Source provenance:
+- Data classification:
+- Confidential reference:
+- Draft status:
+- Human approval:
+- Evidence retention:
+- Rollback / revocation:
+- Residual risk:

--- a/scripts/verify-pre-pr.mjs
+++ b/scripts/verify-pre-pr.mjs
@@ -17,6 +17,7 @@ const requiredFiles = [
   "docs/validation-package/operational-qualification.md",
   "docs/validation-package/performance-qualification.md",
   "docs/validation-package/risk-assessment.md",
+  "docs/validation-package/track-b-validation-delta.md",
   "docs/validation-package/traceability-matrix.md",
   "docs/validation-package/user-requirements-specification.md",
   "docs/validation-package/validation-plan.md",
@@ -288,6 +289,7 @@ if (await fileExists("docs/validation-package/README.md")) {
     "automatic quality decision",
     "artifact safety",
     "synthetic-only public examples",
+    "track b validation delta",
     "not a validated workflow",
     "not a compliance guarantee"
   ]) {
@@ -302,6 +304,7 @@ const validationPackageExpectations = new Map([
   ["docs/validation-package/user-requirements-specification.md", ["user requirements specification", "urs", "requirement id", "acceptance approach", "human approval", "draft-only", "open placeholders"]],
   ["docs/validation-package/functional-specification.md", ["functional specification", "fs", "requirement link", "design placeholder", "erpnext", "ensen evidence", "audit", "open placeholders"]],
   ["docs/validation-package/risk-assessment.md", ["risk assessment", "risk id", "hazard", "control", "severity", "occurrence", "detectability", "open placeholders"]],
+  ["docs/validation-package/track-b-validation-delta.md", ["track b validation delta", "customer-confidential", "regulated input", "source provenance", "data classification", "confidential reference", "draft status", "human approval", "evidence retention", "rollback / revocation", "residual risk", "intended use", "artifact safety", "read-only input controls", "draft-only output controls", "open placeholders", "not a validated workflow", "not a compliance guarantee"]],
   ["docs/validation-package/traceability-matrix.md", ["traceability matrix", "urs id", "fs id", "risk id", "iq", "oq", "pq", "open placeholders"]],
   ["docs/validation-package/installation-qualification.md", ["installation qualification", "iq", "prerequisite", "evidence placeholder", "expected result", "open placeholders"]],
   ["docs/validation-package/operational-qualification.md", ["operational qualification", "oq", "test objective", "acceptance criteria", "evidence placeholder", "open placeholders"]],


### PR DESCRIPTION
## Summary
- add a draft-only Track B validation package delta for customer-confidential and regulated input boundaries
- link the delta from README and validation package navigation
- tighten pre-PR verification to require the delta and required placeholder language

## Verification
- npm run verify:pre-pr
- manual wording scan for forbidden compliance guarantee phrases and workstation-local path literals

Closes #14